### PR TITLE
fix window use after move

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -264,7 +264,9 @@ async fn discord() -> Result<()> {
             } => {
                 #[cfg(target_os = "macos")]
                 if menu_id == close_item.clone().id() {
-                    window.set_minimized(true)
+                    if let Some(webview) = &_webview {
+                        webview.window().set_minimized(true)
+                    }
                 }
                 log::write(
                     format!( "Clicked on {:?}", menu_id),


### PR DESCRIPTION
### Description of the changes
Fix https://github.com/japandotorg/LemonCord/issues/36 (I'm doing this for fun to learn Rust)


### Have the changes in this PR been tested?
Kind of. It compiles, but I think my Mac is too old (2015) and when I actually run the app, I just get a blank white screen.
<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->

Here's the output
```
$ cargo run --release
warning: unused import: `Icon`
  --> src/main.rs:13:41
   |
13 |         window::{WindowBuilder, Window, Icon}, 
   |                                         ^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unexpected `cfg` condition value: `devtools`
   --> src/main.rs:240:11
    |
240 |     #[cfg(feature = "devtools")]
    |           ^^^^^^^^^^^^^^^^^^^^ help: remove the condition
    |
    = note: no expected values for `feature`
    = help: consider adding `devtools` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

warning: unexpected `cfg` condition value: `devtools`
   --> src/main.rs:233:59
    |
233 |                 .with_devtools(cfg!(any(debug_assertions, feature = "devtools")))
    |                                                           ^^^^^^^^^^^^^^^^^^^^ help: remove the condition
    |
    = note: no expected values for `feature`
    = help: consider adding `devtools` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration

warning: `lemon-cord` (bin "lemon-cord") generated 3 warnings (run `cargo fix --bin "lemon-cord"` to apply 1 suggestion)
    Finished `release` profile [optimized] target(s) in 0.56s
     Running `target/release/lemon-cord`
[LOG]: LemonCord : "0.1.2"
[LOG]: Discord web view successfully started.


```

Also (likely because of some system compiler/linker configuration issue on my side), I had to make the following change to get it to compile locally:
```
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,7 +11,7 @@ linker = "i686-unknown-linux-gnu"
 linker = "x86_64-pc-windows-gnu"
 
 [target.x86_64-apple-darwin]
-linker = "x86_64-apple-darwin"
+linker = "clang"
 
 [target.armv7-unknown-linux-musleabi]
 linker = "armv7-unknown-linux-musleabi"
```

But just in case that problem isn't specific to me, I'm including it here for others' reference.